### PR TITLE
Implement #5 Remember selected webcam

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -8,13 +8,27 @@ import { guiControllers, settings } from "./settings";
 
 export class CameraManager {
   private _videoElement: p5.Video | null = null;
-  private _cameraSel: p5.Element | null = null;
+  private _cameraMenu: p5.Element | null = null;
 
-  static async create(p5: p5): Promise<CameraManager> {
-    const instance = new CameraManager();
+  // Clients must use this to create a CameraManager, in order to ensure that
+  // the camera is initialized before the CameraManager is returned.
+  //
+  // This is necessary because the camera initialization is asynchronous.
+  // A constructor cannot be asynchronous, so we can't initialize the camera
+  // in the constructor.
+  static async create(
+    p5: p5,
+    initialCameraName: string | null
+  ): Promise<CameraManager> {
+    const instance = new CameraManager(initialCameraName);
     await instance.initialize(p5);
     return instance;
   }
+
+  // Declaring this `private` prevents clients from calling `new
+  // CameraManager()` without going through `CameraManager.create()`, which
+  // calls `initialize()`.
+  private constructor(private _initialCameraName: string | null) {}
 
   private async initialize(p5: p5): Promise<void> {
     const streamLoaded = new Promise((resolve) => {
@@ -31,7 +45,7 @@ export class CameraManager {
     this.updateMirror();
     guiControllers.mirrorVideo.onFinishChange(() => this.updateMirror());
     await streamLoaded;
-    await this.setupChooseCamera(p5);
+    await this.createCameraMenu(p5);
   }
 
   updateMirror() {
@@ -42,41 +56,63 @@ export class CameraManager {
     }
   }
 
-  private async setupChooseCamera(p5: p5): Promise<void> {
-    const devices = await navigator.mediaDevices.enumerateDevices();
-    const cameras = devices
-      .filter((d) => d.kind === "videoinput")
-      .filter((d) => !d.label.match(/OBS Virtual Camera/));
+  private async createCameraMenu(p5: p5): Promise<void> {
+    const cameras = await this.getCameras();
 
+    // Create the camera menu
     p5.createDiv("Camera:").class("label").parent("camera-container");
-    this._cameraSel = p5.createSelect().parent("camera-container");
+    this._cameraMenu = p5.createSelect().parent("camera-container");
+
+    // Add the cameras to the menu
     for (const camera of cameras) {
-      const optionName = getCameraName(camera);
-      this._cameraSel.option(optionName);
+      const optionName = this.getCameraName(camera);
+      this._cameraMenu.option(optionName);
     }
+
+    // Set the menu to the selected camera.
     // FIXME remove the cast to any. HTMLVideoElement.srcObject is typed as
     // MediaProvider, but it actually implements MediaStream.
     // TODO verify that this.video.elt.srcObject is a MediaStream.
-    this._cameraSel.selected(
-      getCameraName(
-        (this._videoElement!.elt.srcObject as any).getVideoTracks()[0]
-      )
-    );
+    const cameraName =
+      this._initialCameraName &&
+      cameras.find((c) => this.getCameraName(c) === this._initialCameraName)
+        ? this._initialCameraName
+        : this.getCameraName(
+            (this._videoElement!.elt.srcObject as any).getVideoTracks()[0]
+          );
+    this._cameraMenu.selected(cameraName);
 
-    this._cameraSel.changed(async () => {
-      // TODO verify that this.cameraSel is not null.
-      const optionName = this._cameraSel!.value();
-      const camera = cameras.find((c) => getCameraName(c) === optionName)!;
-      const { deviceId } = camera;
-      const mediaStream = await navigator.mediaDevices.getUserMedia({
-        video: { deviceId },
-      });
-      this._videoElement!.elt.srcObject = mediaStream;
-    });
+    // When the camera is changed, update the video element.
+    this._cameraMenu.changed(() => this.onCameraChanged());
+  }
 
-    function getCameraName(camera: MediaDeviceInfo) {
-      return camera.label.replace(/\(.*\)$/g, "");
+  private getCameraName(camera: MediaDeviceInfo) {
+    return camera.label.replace(/\(.*\)$/g, "");
+  }
+
+  private async getCameras() {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices
+      .filter((d) => d.kind === "videoinput")
+      .filter((d) => !d.label.match(/OBS Virtual Camera/));
+  }
+
+  private async onCameraChanged() {
+    const cameras = await this.getCameras();
+    if (!this._cameraMenu) {
+      throw new Error("CameraManager not initialized");
     }
+    const optionName = this._cameraMenu.value();
+    const camera = cameras.find((c) => this.getCameraName(c) === optionName);
+    if (!camera) {
+      alert(`Camera ${optionName} not found`);
+      return;
+    }
+    const { deviceId } = camera;
+    const mediaStream = await navigator.mediaDevices.getUserMedia({
+      video: { deviceId },
+    });
+    this._videoElement!.elt.srcObject = mediaStream;
   }
 
   public get videoElement(): p5.Video {

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -6,63 +6,83 @@
 import p5 from "p5";
 import { guiControllers, settings } from "./settings";
 
-export let video: p5.Video;
+export class CameraManager {
+  private _videoElement: p5.Video | null = null;
+  private _cameraSel: p5.Element | null = null;
 
-let cameraSel: p5.Element;
-
-export async function initializeWebcam(p5: p5): Promise<void> {
-  const streamLoaded = new Promise((resolve) => {
-    video = p5.createCapture(p5.VIDEO, () => resolve(video));
-  });
-  video.size(settings.width, settings.height);
-  video.parent("sketch-container");
-  if (settings.drawVideoOnCanvas) {
-    video.hide();
+  static async create(p5: p5): Promise<CameraManager> {
+    const instance = new CameraManager();
+    await instance.initialize(p5);
+    return instance;
   }
 
-  updateMirror();
-  guiControllers.mirrorVideo.onFinishChange(updateMirror);
-  await streamLoaded;
-  await setupChooseCamera(p5);
+  private async initialize(p5: p5): Promise<void> {
+    const streamLoaded = new Promise((resolve) => {
+      this._videoElement = p5.createCapture(p5.VIDEO, () =>
+        resolve(this._videoElement)
+      );
+      this._videoElement.size(settings.width, settings.height);
+      this._videoElement.parent("sketch-container");
+      if (settings.drawVideoOnCanvas) {
+        this._videoElement.hide();
+      }
+    });
 
-  function updateMirror() {
+    this.updateMirror();
+    guiControllers.mirrorVideo.onFinishChange(() => this.updateMirror());
+    await streamLoaded;
+    await this.setupChooseCamera(p5);
+  }
+
+  updateMirror() {
     if (settings.mirrorVideo) {
-      video.addClass("mirror");
+      this._videoElement?.addClass("mirror");
     } else {
-      video.removeClass("mirror");
+      this._videoElement?.removeClass("mirror");
     }
   }
-}
 
-async function setupChooseCamera(p5: p5): Promise<void> {
-  const devices = await navigator.mediaDevices.enumerateDevices();
-  const cameras = devices
-    .filter((d) => d.kind === "videoinput")
-    .filter((d) => !d.label.match(/OBS Virtual Camera/));
+  private async setupChooseCamera(p5: p5): Promise<void> {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const cameras = devices
+      .filter((d) => d.kind === "videoinput")
+      .filter((d) => !d.label.match(/OBS Virtual Camera/));
 
-  p5.createDiv("Camera:").class("label").parent("camera-container");
-  cameraSel = p5.createSelect().parent("camera-container");
-  for (const camera of cameras) {
-    const optionName = getCameraName(camera);
-    cameraSel.option(optionName);
-  }
-  // FIXME remove the cast to any. HTMLVideoElement.srcObject is typed as
-  // MediaProvider, but it actually implements MediaStream.
-  cameraSel.selected(
-    getCameraName((video.elt.srcObject as any).getVideoTracks()[0])
-  );
+    p5.createDiv("Camera:").class("label").parent("camera-container");
+    this._cameraSel = p5.createSelect().parent("camera-container");
+    for (const camera of cameras) {
+      const optionName = getCameraName(camera);
+      this._cameraSel.option(optionName);
+    }
+    // FIXME remove the cast to any. HTMLVideoElement.srcObject is typed as
+    // MediaProvider, but it actually implements MediaStream.
+    // TODO verify that this.video.elt.srcObject is a MediaStream.
+    this._cameraSel.selected(
+      getCameraName(
+        (this._videoElement!.elt.srcObject as any).getVideoTracks()[0]
+      )
+    );
 
-  cameraSel.changed(async () => {
-    const optionName = cameraSel.value();
-    const camera = cameras.find((c) => getCameraName(c) === optionName)!;
-    const { deviceId } = camera;
-    const mediaStream = await navigator.mediaDevices.getUserMedia({
-      video: { deviceId },
+    this._cameraSel.changed(async () => {
+      // TODO verify that this.cameraSel is not null.
+      const optionName = this._cameraSel!.value();
+      const camera = cameras.find((c) => getCameraName(c) === optionName)!;
+      const { deviceId } = camera;
+      const mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: { deviceId },
+      });
+      this._videoElement!.elt.srcObject = mediaStream;
     });
-    video.elt.srcObject = mediaStream;
-  });
 
-  function getCameraName(camera: MediaDeviceInfo) {
-    return camera.label.replace(/\(.*\)$/g, "");
+    function getCameraName(camera: MediaDeviceInfo) {
+      return camera.label.replace(/\(.*\)$/g, "");
+    }
+  }
+
+  public get videoElement(): p5.Video {
+    if (this._videoElement === null) {
+      throw new Error("CameraManager not initialized");
+    }
+    return this._videoElement;
   }
 }

--- a/src/metaballs.ts
+++ b/src/metaballs.ts
@@ -3,11 +3,15 @@
  */
 
 import p5 from "p5";
-import { video } from "./camera";
 import { confidenceThreshold, settings } from "./settings";
 import { BlazePose } from "./types";
 
 let metaballShader: p5.Shader;
+// FIXME - this is a hack to get the video dimensions
+// The correct way to do this is to pass the video dimensions to the shader.
+// This is extra mechanism and this shader may be on its way out, so I'm not
+// investing the time to do that right now.
+const videoDimensions = { width: 1280, height: 720 };
 
 export function preloadMetaballs(p5: p5) {
   metaballShader = p5.loadShader(
@@ -56,11 +60,11 @@ function setMetaballPoints(p5: p5, shader: p5.Shader, pose: BlazePose.Pose) {
       if (keypoint.score >= confidenceThreshold) {
         shader.setUniform(
           `${keypoint.name}_x`,
-          p5.map(keypoint.x, 0, video.width, xRangeMin, xRangeMax)
+          p5.map(keypoint.x, 0, videoDimensions.width, xRangeMin, xRangeMax)
         );
         shader.setUniform(
           `${keypoint.name}_y`,
-          p5.map(keypoint.y, 0, video.height, yRangeMin, yRangeMax)
+          p5.map(keypoint.y, 0, videoDimensions.height, yRangeMin, yRangeMax)
         );
       } else {
         shader.setUniform(`${keypoint.name}_x`, -1);
@@ -75,11 +79,11 @@ function setMetaballPoints(p5: p5, shader: p5.Shader, pose: BlazePose.Pose) {
   if (hip_score >= confidenceThreshold) {
     shader.setUniform(
       "hip_x",
-      p5.map(hip_x / 2, 0, video.width, xRangeMin, xRangeMax)
+      p5.map(hip_x / 2, 0, videoDimensions.width, xRangeMin, xRangeMax)
     );
     shader.setUniform(
       "hip_y",
-      p5.map(hip_y / 2, 0, video.height, yRangeMin, yRangeMax)
+      p5.map(hip_y / 2, 0, videoDimensions.height, yRangeMin, yRangeMax)
     );
   } else {
     shader.setUniform("hip_x", -1);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,7 +22,32 @@ const reloadPageOnModeChange = Boolean(
 // have in order to be used in the presentation.
 export let confidenceThreshold = 0.95;
 
-export const settings = {
+// #region cameraName
+//
+// TODO: Replace this with a more general solution for storing all the settings.
+// See issue #4 Save configuration information to localStorage
+
+const CAMERA_NAME_KEY = "cameraName";
+
+function getCameraName(): string | null {
+  return localStorage[CAMERA_NAME_KEY];
+}
+
+export function setCameraName(name: string) {
+  settings.cameraName = name;
+  localStorage[CAMERA_NAME_KEY] = name;
+}
+// #endregion
+
+// A minimal specification of a subset of the  `settings` object. This is jsut
+// enough to tell the compiler that cameraName, although initialized to null,
+// can also be a string.
+type Settings = {
+  cameraName: string | null;
+  [key: string]: any;
+};
+
+export const settings: Settings = {
   name: "",
   mirrorVideo: true,
   showSelf: true,
@@ -33,6 +58,7 @@ export const settings = {
   metaballRadius: 0.5,
 
   // These don't have GUI settings at the moment
+  cameraName: getCameraName(),
   width: 880,
   height: 500,
   toroidalMovement: true,

--- a/src/sketch.ts
+++ b/src/sketch.ts
@@ -1,6 +1,6 @@
 import p5 from "p5";
 import { initializeBlazePose } from "./blazePose";
-import { initializeWebcam, video } from "./camera";
+import { CameraManager } from "./camera";
 import { drawPose } from "./drawPose";
 import { initializeGallery, updateGallery } from "./gallery";
 import { preloadMetaballs } from "./metaballs";
@@ -14,6 +14,8 @@ import * as dashboard from "./dashboard";
 // function that is called with the p5 instance as an argument.
 // See https://github.com/processing/p5.js/wiki/Global-and-instance-mode
 new p5((sk: p5) => {
+  let videoElement: HTMLVideoElement;
+
   const sketch = {
     preload() {
       preloadMetaballs(sk);
@@ -35,10 +37,11 @@ new p5((sk: p5) => {
 
       // initializeWebcam calls createVideo(CAMERA). It returns a Promise that
       // resolves when the video stream is ready.
-      await initializeWebcam(sk);
+      const camera = await CameraManager.create(sk);
+      videoElement = camera.videoElement.elt;
       document.body.classList.add("video-initialized");
 
-      await initializeBlazePose(video.elt);
+      await initializeBlazePose(camera.videoElement.elt);
       document.body.classList.add("detector-initialized");
 
       dashboard.initialize();
@@ -60,10 +63,10 @@ new p5((sk: p5) => {
       if (settings.drawVideoOnCanvas) {
         sk.push();
         if (settings.mirrorVideo) {
-          sk.translate(video.width, 0);
+          sk.translate(videoElement.width, 0);
           sk.scale(-1, 1);
         }
-        sk.image(video, 0, 0);
+        sk.image(videoElement, 0, 0);
         sk.pop();
       }
 

--- a/src/sketch.ts
+++ b/src/sketch.ts
@@ -6,7 +6,7 @@ import { initializeGallery, updateGallery } from "./gallery";
 import { preloadMetaballs } from "./metaballs";
 import { getOwnRecord, getPerformers } from "./performers";
 import { movePoseInDirection, updateOffset } from "./poseOffset";
-import { settings } from "./settings";
+import { setCameraName, settings } from "./settings";
 import { connectWebsocket } from "./socket";
 import * as dashboard from "./dashboard";
 
@@ -37,7 +37,8 @@ new p5((sk: p5) => {
 
       // initializeWebcam calls createVideo(CAMERA). It returns a Promise that
       // resolves when the video stream is ready.
-      const camera = await CameraManager.create(sk);
+      const camera = await CameraManager.create(sk, settings.cameraName);
+      camera.on("cameraName", (newCameraName) => setCameraName(newCameraName));
       videoElement = camera.videoElement.elt;
       document.body.classList.add("video-initialized");
 


### PR DESCRIPTION
This PR saves the selected webcam into `localStorage`. On subsequent load, if there is a webcam with the stored display name, it is selected.

The implementation introduces an EventEmitter that sends the display name of the camera when this changes. In an effort to untangle some of the dependencies, the `sketch` module is responsible for using this to connect the camera to the settings.

The PR also encapsulates the functions and variables in the `camera` module into a class. This was done first, in order to make it easier to work with the code.

For ease of review, these changes are implemented as separate commits.