### PR TITLE
Features/user specific avatar type

### DIFF
--- a/common/messages.ts
+++ b/common/messages.ts
@@ -19,4 +19,5 @@ export type UserDetails = {
   id: string;
   name: string;
   roomName?: string;
+  appearance: string;
 };

--- a/common/messages.ts
+++ b/common/messages.ts
@@ -7,6 +7,7 @@ export type Performer = {
   connected: boolean;
   hue: number;
   position: number;
+  appearance: string;
 };
 
 export type Room = {

--- a/server/server.ts
+++ b/server/server.ts
@@ -126,6 +126,8 @@ io.on("connection", (socket: ClientToServerEvent) => {
     if (!performer) {
       performer = findOrCreatePerformer(userDetails);
       io.emit("performers", getPerformersForBroadcast());
+    } else {
+      performer.appearance = userDetails.appearance;
     }
     performer.timestamp = new Date();
     socket.broadcast.volatile.emit("pose", performer, pose);

--- a/src/drawPose.ts
+++ b/src/drawPose.ts
@@ -44,7 +44,8 @@ export function drawPose(p5: p5, person: Performer, outline: boolean): void {
     drawKeypoints(p5, pose, testKeypointColor, outline);
   }
 
-  switch (settings.appearance) {
+  // switch (settings.appearance) {
+  switch (person.appearance) {
     case "metaballs":
       {
         const self = getOwnRecord();

--- a/src/performers.ts
+++ b/src/performers.ts
@@ -32,6 +32,7 @@ poseEmitter.on("pose", (pose: BlazePose.Pose) => {
       name: username,
       isSelf: true,
       connected: true,
+      appearance: settings.apperance,
     },
     pose
   );
@@ -61,7 +62,7 @@ export function updatePersonPose(
       timestamp: 0,
       previousPoses: [createEmptyPose()],
       polishedPose: createEmptyPose(),
-      appearance: DEFAULT_APPEARANCE,
+      // appearance: DEFAULT_APPEARANCE,
     });
   }
   const { position } = performers[ix];

--- a/src/performers.ts
+++ b/src/performers.ts
@@ -32,7 +32,7 @@ poseEmitter.on("pose", (pose: BlazePose.Pose) => {
       name: username,
       isSelf: true,
       connected: true,
-      appearance: settings.apperance,
+      appearance: settings.apperance, // TODO: double-check if this updatePersonPose is local
     },
     pose
   );

--- a/src/performers.ts
+++ b/src/performers.ts
@@ -12,7 +12,7 @@ import { BlazePose, Performer, Person } from "./types";
 import { clientId, username } from "./username";
 
 import EventEmitter from "events";
-import { settings } from "./settings";
+import { settings, DEFAULT_APPEARANCE } from "./settings";
 
 /** Emits "performers" event when the list of performers is updated. */
 export const performersEmitter = new EventEmitter();
@@ -61,6 +61,7 @@ export function updatePersonPose(
       timestamp: 0,
       previousPoses: [createEmptyPose()],
       polishedPose: createEmptyPose(),
+      appearance: DEFAULT_APPEARANCE,
     });
   }
   const { position } = performers[ix];

--- a/src/performers.ts
+++ b/src/performers.ts
@@ -12,7 +12,7 @@ import { BlazePose, Performer, Person } from "./types";
 import { clientId, username } from "./username";
 
 import EventEmitter from "events";
-import { settings, DEFAULT_APPEARANCE } from "./settings";
+import { settings } from "./settings";
 
 /** Emits "performers" event when the list of performers is updated. */
 export const performersEmitter = new EventEmitter();
@@ -32,7 +32,7 @@ poseEmitter.on("pose", (pose: BlazePose.Pose) => {
       name: username,
       isSelf: true,
       connected: true,
-      appearance: settings.apperance, // TODO: double-check if this updatePersonPose is local
+      appearance: settings.appearance, // TODO: double-check if this updatePersonPose is local
     },
     pose
   );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,7 @@ import { getHashParameter, setHashParameter } from "./utils";
 // See https://github.com/dataarts/dat.gui#readme
 const gui = new dat.GUI({ autoPlace: false });
 
-const DEFAULT_APPEARANCE = "skeleton";
+export const DEFAULT_APPEARANCE = "skeleton";
 const initialAppearance = getHashParameter("appearance") || DEFAULT_APPEARANCE;
 
 // If true, the page will reload when the appearance changes between one that

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -13,7 +13,7 @@ import { updateRoomFromServer } from "./room";
 import { BlazePose, Performer, Person, Room } from "./types";
 import { clientId, username } from "./username";
 import { getQueryString } from "./utils";
-import { settings } from "settings";
+import { settings } from "./settings";
 
 const socket = io();
 

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -13,6 +13,7 @@ import { updateRoomFromServer } from "./room";
 import { BlazePose, Performer, Person, Room } from "./types";
 import { clientId, username } from "./username";
 import { getQueryString } from "./utils";
+import { settings } from "settings";
 
 const socket = io();
 
@@ -94,9 +95,9 @@ export function connectWebsocket() {
 poseEmitter.on("translatedPose", (pose: BlazePose.Pose) => {
   socket.emit(
     "pose",
-    { id: clientId, name: username } as Messages.UserDetails,
+    { id: clientId, name: username, appearance: settings.appearance } as Messages.UserDetails,
     pose
-  );
+  ); // TODO: only emit appearance upon change
 });
 
 // TODO: test whether this works in the Edge browser

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type Performer = Messages.Performer & {
   row: number;
   previousPoses: BlazePose.Pose[];
   polishedPose: BlazePose.Pose;
-  appearance: String; // if modifying this data structure, also change it in "performers.ts"
+  appearance: string; // if modifying this data structure, change it in "performers.ts" as well
 };
 
 export type Person = {
@@ -18,6 +18,7 @@ export type Person = {
   connected: boolean;
   isSelf: boolean;
   hue?: number;
+  appearance: string; // if modifying this data structure, change it in "performers.ts" as well
 };
 
 export type Room = Messages.Room & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type Performer = Messages.Performer & {
   row: number;
   previousPoses: BlazePose.Pose[];
   polishedPose: BlazePose.Pose;
+  appearance: String; // if modifying this data structure, also change it in "performers.ts"
 };
 
 export type Person = {


### PR DESCRIPTION
### Client sending `appearance`
In `common/messages.ts`, I add `appearance` into the `UserDetails` data structure,
```typescript
export type UserDetails = {
  ...;
  appearance: string;
};
```
which will be sent over to server through socket in `src/socket.ts`.
```typescript
poseEmitter.on("translatedPose", (pose: BlazePose.Pose) => {
  socket.emit(
    "pose",
    { id: clientId, name: username, appearance: settings.appearance } as Messages.UserDetails,
    pose
  ); // TODO: only emit appearance upon change
});
``` 
### Server processing `appearance`
`appearance` is passed to `server/server.ts` through socket
```typescript
socket.on("pose", (userDetails: Messages.UserDetails, pose: unknown) => { ... });
```
and later updated in `performer` through the following lines (I add the `else` clause)
```typescript
    if (!performer) {
      performer = findOrCreatePerformer(userDetails);
      io.emit("performers", getPerformersForBroadcast());
    } else {
      performer.appearance = userDetails.appearance;
    }
```
which in turn will be sent back to clients through 
```typescript
socket.broadcast.volatile.emit("pose", performer, pose);
```
### Client receiving `appearance`
Clients listens to pose through 
```typescript
  socket.on("pose", (person: Person, pose: BlazePose.Pose) => {
    updatePersonPose(person, pose);
  });
```
and update `appearance` in `updatePersonPose()` function, in specific the following line:
```typescript
performers.push({
      ...person,
})
```
Recall that `appearance` has been added to both `Performer` and `Person` data structures, so the passing of this property should not be an issue.
Later in `drawPose()` function, `settings.appearance` is replaced by `person.appearance` to reflect user specific appearance.
```typescript
  // switch (settings.appearance) {
  switch (person.appearance) {
```