### PR TITLE
Features/gui controller

### DIFF
--- a/src/drawPose.ts
+++ b/src/drawPose.ts
@@ -33,7 +33,7 @@ export function drawPose(p5: p5, person: Performer, outline: boolean): void {
   // drawKeypoints(p5, polishedPose, keypointColor, !outline);
 
   // test draw previous poses
-  if (settings.debugging) {
+  if (settings.drawPreviousPoses) {
     let testH = hue;
     let testS = 100;
     let testB = 100;

--- a/src/drawPose.ts
+++ b/src/drawPose.ts
@@ -11,7 +11,7 @@ import {
   partNames,
   translatePose,
 } from "./pose-utils";
-import { confidenceThreshold, settings } from "./settings";
+import { settings } from "./settings";
 import { createSkeleton } from "./skeleton";
 import { BlazePose, Performer } from "./types";
 
@@ -91,7 +91,7 @@ function drawKeypoints(
     p5.strokeWeight(1);
   }
   for (const keypoint of pose.keypoints) {
-    if (keypoint.score >= confidenceThreshold) {
+    if (keypoint.score >= settings.confidenceThreshold) {
       p5.circle(keypoint.x, keypoint.y, 10);
     }
   }
@@ -101,7 +101,7 @@ function drawSkeleton(p5: p5, pose: BlazePose.Pose, c: p5.Color): void {
   p5.stroke(c);
   p5.strokeWeight(2);
   for (const [p1, p2] of createSkeleton(pose)) {
-    if (p5.min(p1.score, p2.score) >= confidenceThreshold) {
+    if (p5.min(p1.score, p2.score) >= settings.confidenceThreshold) {
       p5.line(p1.x, p1.y, p2.x, p2.y);
     }
   }
@@ -120,7 +120,7 @@ function drawPoseOutline(
     p5.beginShape();
     for (const name of partNames) {
       const keypoint = findPart(pose, name);
-      if (keypoint && keypoint.score >= confidenceThreshold) {
+      if (keypoint && keypoint.score >= settings.confidenceThreshold) {
         if (curved && name.match(/elbow|knee/i)) {
           p5.curveVertex(keypoint.x, keypoint.y);
         } else {

--- a/src/drawPose.ts
+++ b/src/drawPose.ts
@@ -36,11 +36,11 @@ export function drawPose(p5: p5, person: Performer, outline: boolean): void {
   if (settings.drawPreviousPoses) {
     let testH = hue;
     let testS = 100;
-    let testB = 100;
+    let testB = 0;
     let testKeypointColor = p5.color(testH, testS, testB);
     for (let pose of previousPoses) {
       // testH += 360 / settings.posesMaxLength;
-      testB -= 100 / settings.posesMaxLength;
+      testB += 100 / settings.posesMaxLength;
       testKeypointColor = p5.color(testH, testS, testB);
       drawKeypoints(p5, pose, testKeypointColor, outline);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -75,6 +75,7 @@ export const settings: Settings = {
   // debugging info
   debugging: false,
   confidenceThreshold: confidenceThreshold,
+  drawPreviousPoses: false,
 };
 
 var debuggingInfoFolder: dat.GUI;
@@ -90,10 +91,23 @@ export const guiControllers = {
 gui.add(settings, "metaballRadius", 0.25, 2).name("Metaball Radius");
 gui.add(settings, "smoothing", 0, 0.95, 0.05);
 gui.add(settings, "trail", 0, 10);
+
+let numOfPrevPosesSlider: dat.GUIController;
 gui.add(settings, "debugging").onChange( () => {
   if (settings.debugging) {
     debuggingInfoFolder = gui.addFolder("debugging info");
-    debuggingInfoFolder.add(settings, "confidenceThreshold", 0.05, 0.95, 0.05);
+    debuggingInfoFolder.add(settings, "confidenceThreshold", 0.05, 0.95, 0.05).onChange( () => {
+      // The line below updates confidenceThreshold (NOT settings.confidenceThreshold), which most scripts reference
+      // temporarily commented out for the avatar contrast between camera and gallery
+      // confidenceThreshold = settings.confidenceThreshold; 
+    });
+    debuggingInfoFolder.add(settings, "drawPreviousPoses").onChange( () => {
+      if (settings.drawPreviousPoses) {
+        numOfPrevPosesSlider = debuggingInfoFolder.add(settings, "posesMaxLength", 0, 100, 5);
+      } else {
+        debuggingInfoFolder.remove(numOfPrevPosesSlider);
+      }
+    });
   } else {
     gui.removeFolder(debuggingInfoFolder);
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -74,7 +74,7 @@ export const settings: Settings = {
 
   // debugging info
   debugging: false,
-  // confidenceThreshold: confidenceThreshold,
+  confidenceThreshold: confidenceThreshold,
 };
 
 var debuggingInfoFolder: dat.GUI;
@@ -93,7 +93,7 @@ gui.add(settings, "trail", 0, 10);
 gui.add(settings, "debugging").onChange( () => {
   if (settings.debugging) {
     debuggingInfoFolder = gui.addFolder("debugging info");
-    // debuggingInfoFolder.add(settings, "confidenceThreshold", 0.05, 0.95, 0.05);
+    debuggingInfoFolder.add(settings, "confidenceThreshold", 0.05, 0.95, 0.05);
   } else {
     gui.removeFolder(debuggingInfoFolder);
   }


### PR DESCRIPTION
Now if you turn on `debugging`, a `confidenceThreshold` slider and a `drawPreviousPoses` checkbox will show.
![image](https://github.com/osteele/PoseShare/assets/61158372/c2cd9b50-460a-48bc-af26-4cec27f9e4c8)
When `drawPreviousPoses` is checked, another slider will show to configure the number of previous poses needed to store.
![image](https://github.com/osteele/PoseShare/assets/61158372/8dae45d4-e0c3-4fa6-8a89-ad4237ee371d)

Next steps: 
- For now, the previous poses of a user seem to be stored in every user's data structure over socket, which might be a performance overhead. Fix this so that previous poses are local to users.
- I just realized that I painted previous poses in a way that the more recent past the darker. Fix this.
- Maybe a color picker?

Hi Professor, I would like your opinions on the order of priorities! @osteele 