### PR TITLE
fix coordinates of part `right_hip+left_hip`

### DIFF
--- a/src/pose-utils.ts
+++ b/src/pose-utils.ts
@@ -149,8 +149,8 @@ export function findPart(
     }
     return {
       score: (p1.score + p2.score) / 2,
-      x: p1.x + p2.x,
-      y: p1.x + p2.x,
+      x: (p1.x + p2.x) / 2,
+      y: (p1.y + p2.y) / 2,
     };
   } else {
     return pose.keypoints.find(({ name }) => name === partName);


### PR DESCRIPTION
I notice this code snippet seem to do the job of "finding the midpoint of two parts" in `pose-utils.ts`:
```typescript
export function findPart(...) {
  if (partName.match(/\+/)) {
    // omitted content 
    return {
      score: (p1.score + p2.score) / 2,
      x: p1.x + p2.x,
      y: p1.x + p2.x,
    };
  }
  // omitted content
}
```
And among `partNames` this exception of finding the midpoint only applies to `"right_hip+left_hip"`. After I modified the calculation of `x, y` to 
```typescript
      x: (p1.x + p2.x) / 2,
      y: (p1.y + p2.y) / 2,
```
my kiki avatar now looks like this:
![image](https://github.com/osteele/PoseShare/assets/61158372/7f42b66a-ccea-4233-a5d1-aa2b58b32471)