### PR TITLE
`room.performers` -> `performers` + 1x1 -> 3x3

### DIFF
--- a/server/performers.ts
+++ b/server/performers.ts
@@ -8,7 +8,7 @@ import * as Messages from "@common/messages";
 import { findUnusedPosition, getNamedRoom } from "./rooms";
 import { Performer } from "./types";
 
-let performers: Performer[] = [];
+export let performers: Performer[] = [];
 
 export function logConnectedUsers(): void {
   const connected = performers.filter(({ connected }) => connected);
@@ -22,7 +22,7 @@ export function logConnectedUsers(): void {
   console.log(msg);
 
   function names(people: Performer[]) {
-    return people.map(({ name }) => name).join(", ");
+    return people.map(({ name, position }) => `${name} (${position})`).join(", ");
   }
 }
 

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -63,7 +63,7 @@ export function getNamedRoom(roomName: string | null | undefined): Room {
 
 export function findUnusedPosition(room: Room) {
   // collect the positions that are in use
-  const occupiedPositions = performers.map(({ position }) => position);
+  const occupiedPositions = performers.filter(({room}) => room.name == "default").map(({ position }) => position);
   // create an array of available positions, and then remove the ones that are
   // already in use.
   const availablePositions = Array.from(

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -12,6 +12,7 @@
  */
 import * as fs from "fs";
 import { Room } from "./types";
+import { performers } from "./performers";
 
 const ROOM_CONFIG_PATH = "./config/rooms.json";
 const DEFAULT_ROOM_NAME = "default";
@@ -20,8 +21,8 @@ const DEFAULT_ROOM_NAME = "default";
  * specify a default room, use this instead.  */
 const DEFAULT_ROOM: Room = {
   name: DEFAULT_ROOM_NAME,
-  rows: 1,
-  cols: 1,
+  rows: 3,
+  cols: 3,
   performers: [],
 };
 
@@ -54,7 +55,7 @@ if (fs.existsSync(ROOM_CONFIG_PATH)) {
 export function getNamedRoom(roomName: string | null | undefined): Room {
   const room = rooms[roomName || DEFAULT_ROOM_NAME];
   if (!room) {
-    console.error(`Uknown room: ${roomName}`);
+    console.error(`Unknown room: ${roomName}`);
     return rooms[DEFAULT_ROOM_NAME];
   }
   return room;
@@ -62,13 +63,14 @@ export function getNamedRoom(roomName: string | null | undefined): Room {
 
 export function findUnusedPosition(room: Room) {
   // collect the positions that are in use
-  const occupiedPositions = room.performers.map(({ position }) => position);
+  const occupiedPositions = performers.map(({ position }) => position);
   // create an array of available positions, and then remove the ones that are
   // already in use.
   const availablePositions = Array.from(
     { length: room.rows * room.cols },
     (_, i) => i
   ).filter((p) => !occupiedPositions.includes(p));
+  console.log(`occupiedPositions: [${occupiedPositions}], availablePositions: [${availablePositions}]`);
   return (
     availablePositions.shift() ??
     availablePositions.push(Math.max(...occupiedPositions) + 1)

--- a/server/types.ts
+++ b/server/types.ts
@@ -9,11 +9,7 @@ export type Performer = Messages.Performer & {
 /** The server-side representation of a room. */
 export type Room = Messages.Room & {
   name: string;
-  performers: {
-    id: string;
-    name: string;
-    position: number;
-  }[];
+  performers: Messages.Performer[];
 };
 
 export interface ClientToServerEvent {

--- a/src/room.ts
+++ b/src/room.ts
@@ -15,8 +15,8 @@ import { Room } from "./types";
 // run the client without the server.
 export let room: Room = {
   name: "local",
-  rows: 1,
-  cols: 1,
+  rows: 3,
+  cols: 3,
   performers: [],
 };
 


### PR DESCRIPTION
**Problem:** `room.performers` turns out to be empty, as performers were never pushed to any room.
**Solution:** 1) change `room.performers` to `performers : Message.Performer[]` (imported from `/server/performers.ts`); 2) change the default room size from `1x1` to `3x3`.
**Outcome:** avatars are seperated in the default room (see below); room/position assignment & management is still messed up.
<img width="204" alt="image" src="https://github.com/osteele/PoseShare/assets/61158372/6a8fb8a7-b29b-42bf-a46b-bff6c8f0b96e">
